### PR TITLE
Changed delayed job config to prevent queue buildup

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,0 +1,2 @@
+Delayed::Worker.max_attempts = 1
+Delayed::Worker.max_run_time = 2.seconds


### PR DESCRIPTION
Delayed Job will now only attempt a job once and expect it won't take more
than 2 seconds to run, by default. The jobs run in the project are short and
recurring, so this should prevent them from building up in the queue in case
SOAP doesn't return an answer quickly for any reason. 