### PR TITLE
AgentStatusUpdater no longer estimates whether data is valid

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - 'spec/**/*'
     - 'app/controllers/application_controller.rb'
     - 'Gemfile'
+    - 'vendor/**/*'
 Rails:
   Enabled: true
 Metrics/ClassLength:

--- a/app/jobs/get_agent_contacts_job.rb
+++ b/app/jobs/get_agent_contacts_job.rb
@@ -27,7 +27,7 @@ class GetAgentContactsJob
     120.seconds
   end
 
-  def max_attempts 
+  def max_attempts
     4
   end
 end

--- a/app/jobs/track_agent_statuses_job.rb
+++ b/app/jobs/track_agent_statuses_job.rb
@@ -9,7 +9,7 @@ class TrackAgentStatusesJob
                       time_in_status: data[:time_in_status])
     end
     log = JobLog.new('TrackAgentStatusesJob')
-    log.log_success if AgentStatusUpdater.new(now, log.last_success).update_statuses(current)
+    AgentStatusUpdater.new(now, log.last_success).update_statuses(current)
   end
 
   def max_run_time
@@ -18,6 +18,10 @@ class TrackAgentStatusesJob
 
   def max_attempts
     1
+  end
+
+  def success(*)
+    JobLog.new('TrackAgentStatusesJob').log_success 
   end
 
   def failure(*)

--- a/app/jobs/track_agent_statuses_job.rb
+++ b/app/jobs/track_agent_statuses_job.rb
@@ -9,11 +9,7 @@ class TrackAgentStatusesJob
                       time_in_status: data[:time_in_status])
     end
     log = JobLog.new('TrackAgentStatusesJob')
-    if AgentStatusUpdater.new(now, log.last_success).update_statuses(current)
-      log.log_success
-    else
-      log.log_failure
-    end
+    log.log_success if AgentStatusUpdater.new(now, log.last_success).update_statuses(current)
   end
 
   def max_run_time
@@ -23,7 +19,7 @@ class TrackAgentStatusesJob
   def max_attempts
     1
   end
-
+  
   def failure(*)
     JobLog.new('TrackAgentStatusesJob').log_failure
   end

--- a/app/jobs/track_agent_statuses_job.rb
+++ b/app/jobs/track_agent_statuses_job.rb
@@ -19,7 +19,7 @@ class TrackAgentStatusesJob
   def max_attempts
     1
   end
-  
+
   def failure(*)
     JobLog.new('TrackAgentStatusesJob').log_failure
   end

--- a/app/services/agent_status_updater.rb
+++ b/app/services/agent_status_updater.rb
@@ -18,7 +18,7 @@ class AgentStatusUpdater
     @new_statuses = Hash[new_statuses.map { |status| [status.agent_id, status] }]
     @statuses_to_create = []
 
-    check_when_new_statuses_opened    
+    check_when_new_statuses_opened
     check_signed_out_agents
     update_new_and_changed_statuses
     save_updates
@@ -53,7 +53,7 @@ class AgentStatusUpdater
     # 10 second buffer is included to account for random delays when fetching SOAP responses
     if previous.status != status.status ||
        status.created_at > previous.created_at + 10.seconds
-      
+
       previous.open = false
       save_new_status(status)
     end

--- a/app/services/queue_service.rb
+++ b/app/services/queue_service.rb
@@ -1,3 +1,4 @@
+# Provides functionality for statistical data about the Queue
 class QueueService
   def initialize
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.cache_store = :null_store
+  config.cache_store = :memory_store
 
   config.logger = ActiveSupport::Logger.new(
                      config.paths['log'].first, 1, 5 * 1024 * 1024)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ service_group_ids_by_team = { 'Hakijapalvelut' => 7,
                               'Uaf' => 9 }
 
 backend_service.get_teams.each do |team_name|
-  Team.find_or_initialize_by(name: team_name).tap do |team| 
+  Team.find_or_initialize_by(name: team_name).tap do |team|
     team.filter = team_name == 'Helpdesk'
     team.service_group_id = service_group_ids_by_team[team_name]
     team.save

--- a/spec/services/agent_status_updater_spec.rb
+++ b/spec/services/agent_status_updater_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe AgentStatusUpdater, type: :service do
     end
   end
 
-  context "if an agent's status has the same name but the time has decreased" do 
+  context "if an agent's status has the same name but the time has decreased" do
     before (:example) do 
       old_data = [build(:status_1a, time_in_status: "22"), build(:status_2a, time_in_status: "5")]
       new_data = [build(:status_1a, time_in_status: "15"), build(:status_2a, time_in_status: "20")]
@@ -126,10 +126,7 @@ RSpec.describe AgentStatusUpdater, type: :service do
     end
 
     it "generates a new open status for the statuses where the time in status decreased" do
-      expect(AgentStatus.all.length).to eq(3)
-    end
-
-    it "closes the old statuses correctly" do 
+      expect(AgentStatus.all.length).to eq(3)      
       expect(AgentStatus.first.open).to be(false)
       expect(AgentStatus.second.open).to be(true)
     end
@@ -150,111 +147,88 @@ RSpec.describe AgentStatusUpdater, type: :service do
   end
 
   context "When SOAP data does not arrive in the expected time" do
-  	before (:example) do
-  		@data1=[build(:status_1a, time_in_status: "300"), build(:status_2a, time_in_status: "3")]
-  		@data2=[build(:status_1a, time_in_status: "305"), build(:status_2a, time_in_status: "8"), build(:status_3a, time_in_status: "3")]
-  	end
+    before (:example) do
+      @data1=[build(:status_1a, time_in_status: "300"), build(:status_2a, time_in_status: "3")]
+      @data1copy=[build(:status_1a, time_in_status: "300"), build(:status_2a, time_in_status: "3")]
+      @data2=[build(:status_1a, time_in_status: "305"), build(:status_2a, time_in_status: "8"), build(:status_3a, time_in_status: "3")]
+    end
 
-  	it "handles a situation where SOAP data comes slightly later than expected"  do
-  		time = now
-  		test = updater(time, time - 5.seconds).update_statuses(@data1)
- 		test2  = updater(time + 9.seconds, time).update_statuses(@data2)
-  		expect(AgentStatus.all.length).to eq(3)
-  		expect(AgentStatus.where(open: true).length).to eq(3)
-  		expect(test).to be(true)
-  		expect(test2).to be(true)
+    it "handles a situation where SOAP data comes slightly later than expected"  do
+      time = now
+      updater(time, time - 5.seconds).update_statuses(@data1)
+      updater(time + 9.seconds, time).update_statuses(@data2)
+      expect(AgentStatus.all.length).to eq(3)
+      expect(AgentStatus.where(open: true).length).to eq(3)
     end
 
     it "handles a situation where SOAP data comes slightly earlier than expected" do 
-    	time = now 
-    	test = updater(time, time - 5.seconds).update_statuses(@data1)
- 		test2  = updater(time + 1.second, time).update_statuses(@data2)
-  		expect(AgentStatus.all.length).to eq(3)
-  		expect(AgentStatus.where(open: true).length).to eq(3)
-  		expect(test).to be(true)
-  		expect(test2).to be(true)
+      time = now 
+      updater(time, time - 5.seconds).update_statuses(@data1)
+      updater(time + 1.second, time).update_statuses(@data2)
+      expect(AgentStatus.all.length).to eq(3)
+      expect(AgentStatus.where(open: true).length).to eq(3)
     end
 
     it "handles a situation where the same SOAP response is delivered shortly after the first one" do
-    	time = now
-    	test = updater(time, time - 5.seconds).update_statuses(@data1)
-    	test2 = updater(time + 2.seconds, time).update_statuses(@data1)
-    	expect(AgentStatus.all.length).to eq(2) 
-        expect(AgentStatus.where(open: true).length).to eq(2)
-        expect(test).to be(true)
-  		expect(test2).to be(true)
+      time = now
+      updater(time, time - 5.seconds).update_statuses(@data1)
+      updater(time + 2.seconds, time).update_statuses(@data1)
+      expect(AgentStatus.all.length).to eq(2) 
+      expect(AgentStatus.where(open: true).length).to eq(2)
     end
 
     it "handles a situation where the same SOAP response is delivered fairly late after the first time" do
-    	time = now
-    	test = updater(time, time - 5.seconds).update_statuses(@data1)
-    	test2 = updater(time + 9.seconds, time).update_statuses(@data1)
-    	expect(AgentStatus.all.length).to eq(2) 
-        expect(AgentStatus.where(open: true).length).to eq(2)
-        expect(test).to be(true)
-  		expect(test2).to be(false)
+      time = now
+      updater(time, time - 5.seconds).update_statuses(@data1)
+      updater(time + 9.seconds, time).update_statuses(@data1copy)
+      expect(AgentStatus.all.length).to eq(2)
     end
 
     it "handles a situation where the same SOAP response is delivered shortly after first one, then a new response appears" do
-    	time = now
-    	test = updater(time, time - 5.seconds).update_statuses(@data1)
-    	test2 = updater(time + 2.seconds, time).update_statuses(@data1)
-    	test3 = updater(time + 7.seconds, time + 2.seconds).update_statuses(@data2)
-    	expect(AgentStatus.all.length).to eq(3) 
-        expect(AgentStatus.where(open: true).length).to eq(3)
-        expect(test).to be(true)
-  		expect(test2).to be(true)
-  		expect(test3).to be(true)
+      time = now
+      updater(time, time - 5.seconds).update_statuses(@data1)
+      updater(time + 2.seconds, time).update_statuses(@data1copy)
+      updater(time + 7.seconds, time + 2.seconds).update_statuses(@data2)
+      expect(AgentStatus.all.length).to eq(3) 
+      expect(AgentStatus.where(open: true).length).to eq(3)
     end
 
     it "handles a situation where the same SOAP response is delivered fairly late, then a new response appears" do 
-    	time = now
-    	test = updater(time, time - 5.seconds).update_statuses(@data1)
-    	test2 = updater(time + 9.seconds, time).update_statuses(@data1)
-    	test3 = updater(time + 10.seconds, time).update_statuses(@data2)
-    	expect(AgentStatus.all.length).to eq(3) 
-        expect(AgentStatus.where(open: true).length).to eq(3)
-        expect(test).to be(true)
-  		expect(test2).to be(false)
-  		expect(test3).to be(true)
+      time = now
+      updater(time, time - 5.seconds).update_statuses(@data1)
+      updater(time + 9.seconds, time).update_statuses(@data1copy)
+      updater(time + 10.seconds, time).update_statuses(@data2)
+      expect(AgentStatus.all.length).to eq(3) 
+      expect(AgentStatus.where(open: true).length).to eq(3)
     end
 
     it "handles a situation where the same response is delivered several times over a few seconds, then a new one appears" do
-    	time = now
-    	test = updater(time, time - 5.seconds).update_statuses(@data1)
-    	test2 = updater(time + 1.second, time).update_statuses(@data1)
-    	test3 = updater(time + 2.seconds, time + 1.second).update_statuses(@data1)
-    	test4 = updater(time + 3.seconds, time + 2.seconds).update_statuses(@data2)
-    	test5 = updater(time + 4.seconds, time + 3.seconds).update_statuses(@data2)
-    	test6 = updater(time + 5.seconds, time + 4.seconds).update_statuses(@data2)
+      time = now
+      updater(time, time - 5.seconds).update_statuses(@data1)
+      updater(time + 1.second, time).update_statuses(@data1)
+      updater(time + 2.seconds, time + 1.second).update_statuses(@data1)
+      updater(time + 3.seconds, time + 2.seconds).update_statuses(@data2)
+      updater(time + 4.seconds, time + 3.seconds).update_statuses(@data2)
+      updater(time + 5.seconds, time + 4.seconds).update_statuses(@data2)
 
-    	expect(AgentStatus.all.length).to eq(3) 
-        expect(AgentStatus.where(open: true).length).to eq(3)
-        expect(test).to be(true)
-  		expect(test2).to be(true)
-  		expect(test3).to be(true)
-  		expect(test4).to be(true)
-  		expect(test5).to be(true)
-  		expect(test6).to be(true)
+      expect(AgentStatus.all.length).to eq(3) 
+      expect(AgentStatus.where(open: true).length).to eq(3)      
     end
   end
 
   context "when the SOAP delay gets to be very long" do 
     before(:example) do 
       data1=[build(:status_1a, time_in_status: "300"), build(:status_2a, time_in_status: "3")]
-  	  data2=[build(:status_1a, time_in_status: "305"), build(:status_2a, time_in_status: "8"), build(:status_3a, time_in_status: "3")]
+      data2=[build(:status_1a, time_in_status: "305"), build(:status_2a, time_in_status: "8"), build(:status_3a, time_in_status: "3")]
       data3=[build(:status_1a, time_in_status: "50"), build(:status_2a, time_in_status: "100")]
-      @test1 = updater(now, now - 5.seconds).update_statuses(data1)
-      @test2 = updater(now + 9.seconds, now).update_statuses(data2)
-  	  @test3 = updater(now + 92.seconds, now + 9.seconds).update_statuses(data3)
+      updater(now, now - 5.seconds).update_statuses(data1)
+      updater(now + 9.seconds, now).update_statuses(data2)
+      updater(now + 92.seconds, now + 9.seconds).update_statuses(data3)
     end
 
     it "doesn't confuse old and new data" do
-  	  expect(AgentStatus.all.length).to eq(4)
-  	  expect(AgentStatus.where(open: true).length).to eq(2)
-  	  expect(@test1).to be(true)
-  	  expect(@test2).to be(true)
-  	  expect(@test3).to be(true)
-  	end
-  end
+      expect(AgentStatus.all.length).to eq(4)
+      expect(AgentStatus.where(open: true).length).to eq(2)      
+    end
+  end  
 end


### PR DESCRIPTION
AgentStatusUpdater now accepts all new data as valid.
Estimating whether data is valid did not work as expected in real world
conditions, so valid data was discarded as invalid. Removed system as it
didn't work in practice.