### PR TITLE
Nightly contacts fetch job now finds missed contacts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,12 +43,10 @@ gem 'bcrypt', '~> 3.1.7'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
-group :development, :production do 
-  gem 'daemons'
-  gem 'clockwork', '~> 2.0'
-  gem 'delayed_job'
-  gem 'delayed_job_active_record'
-end
+gem 'daemons'
+gem 'clockwork', '~> 2.0'
+gem 'delayed_job'
+gem 'delayed_job_active_record'
 
 group :test do
   gem 'factory_girl_rails'

--- a/app/jobs/get_service_contacts_job.rb
+++ b/app/jobs/get_service_contacts_job.rb
@@ -1,0 +1,58 @@
+# Gets contacts for every agent in a specific service and stores the results in DB
+class GetServiceContactsJob
+  def initialize(service_id, start_date, end_date)
+    @service_id = service_id
+    @start_date = start_date
+    @end_date = end_date
+  end
+
+  def perform
+    sleep 0.2
+    agents = Agent.all
+    contacts = []
+    BackendService.new.get_service_contacts(@service_id, @start_date, @end_date).each do |data|
+      if data[:agent_name] && data[:agent_name] != ''
+        data[:agent_id] = find_agent_id(agents, data[:agent_name])
+        next if data[:agent_id].nil?
+      else
+        data[:agent_id] = nil
+      end
+      add_contact(contacts, data)
+    end
+    Contact.create(contacts)
+  end
+
+  def queue_name
+    'contacts'
+  end
+
+  def max_run_time
+    600.seconds
+  end
+
+  def max_attempts
+    4
+  end
+
+  private
+
+  def add_contact(contacts, data)
+    contacts.push(agent_id: data[:agent_id],
+                  service_id: @service_id,
+                  contact_type: data[:contact_type],
+                  ticket_id: data[:ticket_id],
+                  arrived_in_queue: data[:arrived],
+                  forwarded_to_agent: data[:forwarded_to_agent],
+                  answered: data[:answered],
+                  call_ended: data[:call_ended],
+                  handling_ended: data[:after_call_ended],
+                  direction: data[:direction])
+  end
+
+  def find_agent_id(agents, agent_name)
+    agent_name = agent_name.split
+    agent = agents.find { |agt| agt.first_name == agent_name[1] && agt.last_name == agent_name[0] }
+    return agent.id if agent
+    nil
+  end
+end

--- a/app/jobs/get_team_contacts_job.rb
+++ b/app/jobs/get_team_contacts_job.rb
@@ -7,16 +7,10 @@ class GetTeamContactsJob
   end
 
   def perform
-    agents = Agent.all
-    services = Service.all
-    contacts = []
-    BackendService.new.get_team_contacts(@team, @start_date, @end_date).each do |data|
-      data[:agent] = find_agent(agents, data[:agent_name])
-      next unless data[:agent]
-      data[:service] = find_service(services, data[:service_name])
-      add_contact(contacts, data)
+    services = Team.find_by(name: @team).services
+    services.each do |service|
+      Delayed::Job.enqueue GetServiceContactsJob.new(service.id, @start_date, @end_date)
     end
-    Contact.create(contacts)
   end
 
   def queue_name
@@ -24,34 +18,10 @@ class GetTeamContactsJob
   end
 
   def max_run_time
-    600.seconds
+    120.seconds
   end
 
   def max_attempts
-    5
-  end
-
-  private
-
-  def add_contact(contacts, data)
-    contacts.push(agent_id: data[:agent].id,
-                  service_id: data[:service].id,
-                  contact_type: data[:contact_type],
-                  ticket_id: data[:ticket_id],
-                  arrived_in_queue: data[:arrived],
-                  forwarded_to_agent: data[:forwarded_to_agent],
-                  answered: data[:answered],
-                  call_ended: data[:call_ended],
-                  handling_ended: data[:after_call_ended],
-                  direction: data[:direction])
-  end
-
-  def find_agent(agents, agent_name)
-    agent_name = agent_name.split
-    agents.find { |agt| agt.first_name == agent_name[1] && agt.last_name == agent_name[0] }
-  end
-
-  def find_service(services, service_name)
-    services.find { |svc| svc.name == service_name } || Service.new
+    1
   end
 end

--- a/app/jobs/track_agent_statuses_job.rb
+++ b/app/jobs/track_agent_statuses_job.rb
@@ -16,20 +16,14 @@ class TrackAgentStatusesJob
   def lunch(states)
     luncheds = Rails.cache.read 'lunched'
 
-    @contacts_service = ContactsService.new
-    time = Time.zone.now
-    start_time = time.beginning_of_day
-    end_time = time.end_of_day
-    team_name = 'Helpdesk'
-
     if luncheds.nil?
-      eaters = @contacts_service.statuses(team_name, start_time, end_time, 'Ruokatunti')
+      eaters = ContactsService.new.statuses('Helpdesk', now.beginning_of_day, now.end_of_day, 'Ruokatunti')
       luncheds = Set.new eaters.pluck(:agent_id)
     end
 
     states.each do |data|
-      agent_id = data[:agent_id].to_i   
-      luncheds.add agent_id if data[:status] == 'Ruokatunti'    
+      agent_id = data[:agent_id].to_i
+      luncheds.add agent_id if data[:status] == 'Ruokatunti'
     end
 
     Rails.cache.write 'lunched', luncheds

--- a/app/services/backend_service.rb
+++ b/app/services/backend_service.rb
@@ -25,6 +25,16 @@ class BackendService
                        contact_type: 'PBX EMAIL SMS FAX SCAN CHAT COBRO MANUAL FACE TASK VIDEO')
   end
 
+  def get_service_contacts(service_id, start_date, end_date)
+    get_agent_contacts(service_group_id: -1,
+                       service_id: service_id,
+                       team_name: '',
+                       agent_id: -1,
+                       start_date: start_date,
+                       end_date: end_date,
+                       contact_type: 'PBX EMAIL SMS FAX SCAN CHAT COBRO MANUAL FACE TASK VIDEO')
+  end
+
   # Method for getting agent contacts
   def get_agent_contacts(params)
     message = {
@@ -35,7 +45,7 @@ class BackendService
       startDate: params[:start_date],
       endDate: params[:end_date],
       contactTypes: params[:contact_type],
-      useServiceTime: true
+      useServiceTime: false
     }
 
     reply = @client.call(:get_contacts, message: message)

--- a/spec/factories/backend_results_factory.rb
+++ b/spec/factories/backend_results_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do 
-  factory :get_team_contacts_1, class: Array do
+  factory :get_service_contacts_1, class: Array do
 
     contact_1 {{ ticket_id: "1",
                  arrived: "2016-06-20 10:00:00",
@@ -31,7 +31,11 @@ FactoryGirl.define do
                  additional_info: nil,
                  destination: nil }}
 
-    contact_2 {{ ticket_id: "2",
+      initialize_with { [contact_1] } 
+  end
+
+  factory :get_service_contacts_2, class: Array do 
+    contact_1 {{ ticket_id: "2",
                  arrived: "2016-06-20 10:00:00",
                  time_in_queue: 120,
                  forwarded_to_agent: "2016-06-20 10:02:00",
@@ -61,8 +65,43 @@ FactoryGirl.define do
                  additional_info: nil,
                  destination: nil }}
 
-      initialize_with { [contact_1, contact_2] } 
+      initialize_with { [contact_1] }
   end
+
+    factory :get_service_contacts_3, class: Array do 
+    contact_1 {{ ticket_id: "1",
+                 arrived: "2016-06-20 10:00:00",
+                 time_in_queue: 30,
+                 forwarded_to_agent: nil,
+                 answered: nil,
+                 call_ended: "2016-06-20 10:00:30",
+                 after_call_ended: nil,
+                 total_response_time: 30,
+                 total_handle_time: 30,
+                 service_name: "Neuvonta Eng",
+                 direction: "I",
+                 contact_type: "PBX",
+                 contact_information: nil,
+                 agent_name: "",
+                 customer_id: "-1",
+                 contact_reason: nil,
+                 information: nil,
+                 ivr_feedback: nil,
+                 category_of_recording: nil,
+                 recorded: nil,
+                 inserted_to_db: "2016-06-20 10:00:00",
+                 task_count: 0,
+                 task_time: 0,
+                 processing_total_sum: 30,
+                 subject: nil,
+                 outbound_campaign_name: nil,
+                 outbound_campaign_id: nil,
+                 additional_info: nil,
+                 destination: nil }}
+
+      initialize_with { [contact_1] }
+  end
+
 
   factory :get_agent_online_state_1, class: Array do
     contact_1 {{

--- a/spec/jobs/get_service_contacts_job_spec.rb
+++ b/spec/jobs/get_service_contacts_job_spec.rb
@@ -1,0 +1,94 @@
+RSpec.describe GetServiceContactsJob, type: :job do
+
+  it "Parses contact results from BackendService correctly, creates Contact objects and sets their attributes correctly" do 
+    Team.create(id: 1, name: "Helpdesk")
+    Agent.create(id: 1, first_name: "Matti", last_name: "Neuvolainen", team_id: 1)
+    Service.create(id: 1, name: "Neuvonta Fin", team_id: 1)
+    data = FactoryGirl.build(:get_service_contacts_1)    
+    allow_any_instance_of(BackendService).to receive(:get_service_contacts).and_return(data)
+    GetServiceContactsJob.new(1, '2016-06-01', '2016-06-10').perform
+
+    contacts = Contact.all
+    expect(contacts.size).to eq(1)
+
+    expect(contacts[0].agent_id).to eq(1)
+    expect(contacts[0].service_id).to eq(1)
+    expect(contacts[0].contact_type).not_to be(nil)
+    expect(contacts[0].ticket_id).not_to be(nil)
+    expect(contacts[0].forwarded_to_agent).not_to be(nil)
+    expect(contacts[0].answered).not_to be(nil)
+    expect(contacts[0].call_ended).not_to be(nil)
+    expect(contacts[0].handling_ended).not_to be(nil)
+    expect(contacts[0].direction).not_to be(nil)
+
+    expect(contacts[0].contact_type).to eq(data[0][:contact_type])
+    expect(contacts[0].ticket_id).to eq(data[0][:ticket_id])
+    expect(contacts[0].forwarded_to_agent).to eq(data[0][:forwarded_to_agent])
+    expect(contacts[0].answered).to eq(data[0][:answered])
+    expect(contacts[0].call_ended).to eq(data[0][:call_ended])
+    expect(contacts[0].handling_ended).to eq(data[0][:after_call_ended])
+    expect(contacts[0].direction).to eq(data[0][:direction])
+
+    Agent.create(id: 2, first_name: "Antti", last_name: "Agentikkala", team_id: 1)
+    Service.create(id: 2, name: "Neuvonta Eng", team_id: 1)
+    data = FactoryGirl.build(:get_service_contacts_2)
+    allow_any_instance_of(BackendService).to receive(:get_service_contacts).and_return(data)
+    GetServiceContactsJob.new(2, '2016-06-01', '2016-06-10').perform
+
+    contacts = Contact.all
+    expect(contacts.size).to eq(2)
+    
+    expect(contacts[1].agent_id).to eq(2)
+    expect(contacts[1].service_id).to eq(2)
+    expect(contacts[1].contact_type).not_to be(nil)
+    expect(contacts[1].ticket_id).not_to be(nil)
+    expect(contacts[1].forwarded_to_agent).not_to be(nil)
+    expect(contacts[1].answered).not_to be(nil)
+    expect(contacts[1].call_ended).not_to be(nil)
+    expect(contacts[1].handling_ended).not_to be(nil)
+    expect(contacts[1].direction).not_to be(nil)
+
+    expect(contacts[1].contact_type).to eq(data[0][:contact_type])
+    expect(contacts[1].ticket_id).to eq(data[0][:ticket_id])
+    expect(contacts[1].forwarded_to_agent).to eq(data[0][:forwarded_to_agent])
+    expect(contacts[1].answered).to eq(data[0][:answered])
+    expect(contacts[1].call_ended).to eq(data[0][:call_ended])
+    expect(contacts[1].handling_ended).to eq(data[0][:after_call_ended])
+    expect(contacts[1].direction).to eq(data[0][:direction])
+  end
+
+  it "Ignores contacts from unknown agents" do
+    Team.create(id: 1, name: 'Helpdesk')
+    Service.create(id: 1, name: 'Neuvonta Fin', team_id: 1)
+    data = FactoryGirl.build(:get_service_contacts_1)
+    allow_any_instance_of(BackendService).to receive(:get_service_contacts).and_return(data)
+    GetServiceContactsJob.new(1, '2016-06-01', '2016-06-10').perform
+    expect(Contact.all.size).to eq(0)
+  end
+
+  it "Correctly stores contacts which were not assigned to any agent(missed contacts)" do
+    Team.create(id: 1, name: "Helpdesk")
+    Service.create(id: 1, name: 'Neuvonta Eng', team_id: 1)
+    data = FactoryGirl.build(:get_service_contacts_3)
+    allow_any_instance_of(BackendService).to receive(:get_service_contacts).and_return(data)
+    GetServiceContactsJob.new(1, '2016-06-01', '2016-06-10').perform
+
+    contacts = Contact.all
+    expect(contacts.size).to eq(1)
+
+    expect(contacts[0].agent_id).to be(nil)
+    expect(contacts[0].service_id).to eq(1)
+    expect(contacts[0].contact_type).not_to be(nil)
+    expect(contacts[0].ticket_id).not_to be(nil)
+    expect(contacts[0].call_ended).not_to be(nil)
+    expect(contacts[0].direction).not_to be(nil)
+
+    expect(contacts[0].contact_type).to eq(data[0][:contact_type])
+    expect(contacts[0].ticket_id).to eq(data[0][:ticket_id])
+    expect(contacts[0].forwarded_to_agent).to eq(data[0][:forwarded_to_agent])
+    expect(contacts[0].answered).to eq(data[0][:answered])
+    expect(contacts[0].call_ended).to eq(data[0][:call_ended])
+    expect(contacts[0].handling_ended).to eq(data[0][:after_call_ended])
+    expect(contacts[0].direction).to eq(data[0][:direction])
+  end
+end

--- a/spec/jobs/get_team_contacts_job_spec.rb
+++ b/spec/jobs/get_team_contacts_job_spec.rb
@@ -1,64 +1,14 @@
 RSpec.describe GetTeamContactsJob, type: :job do 
-
-  it "Parses contact results from BackendService correctly, creates Contact objects and sets their attributes correctly" do 
-    Team.create(id: 1, name: "Helpdesk")
-    Agent.create(id: 1, first_name: "Matti", last_name: "Neuvolainen", team_id: 1)
-    Agent.create(id: 2, first_name: "Antti", last_name: "Agentikkala", team_id: 1)
+  it "Adds a new GetServiceContactsJob to Delayed Job Queue for each service associated with the team" do
+    Team.create(id: 1, name: 'Helpdesk')
     Service.create(id: 1, name: "Neuvonta Fin", team_id: 1)
     Service.create(id: 2, name: "Neuvonta Eng", team_id: 1)
-    data = FactoryGirl.build(:get_team_contacts_1)
-    allow_any_instance_of(BackendService).to receive(:get_team_contacts).and_return(data)
     GetTeamContactsJob.new('Helpdesk', '2016-06-01', '2016-06-10').perform
-
-    contacts = Contact.all
-    expect(contacts.size).to eq(2)
-
-    expect(contacts[0].agent_id).to eq(1)
-    expect(contacts[0].service_id).to eq(1)
-    expect(contacts[0].contact_type).not_to be(nil)
-    expect(contacts[0].ticket_id).not_to be(nil)
-    expect(contacts[0].forwarded_to_agent).not_to be(nil)
-    expect(contacts[0].answered).not_to be(nil)
-    expect(contacts[0].call_ended).not_to be(nil)
-    expect(contacts[0].handling_ended).not_to be(nil)
-    expect(contacts[0].direction).not_to be(nil)
-
-    expect(contacts[0].contact_type).to eq(data[0][:contact_type])
-    expect(contacts[0].ticket_id).to eq(data[0][:ticket_id])
-    expect(contacts[0].forwarded_to_agent).to eq(data[0][:forwarded_to_agent])
-    expect(contacts[0].answered).to eq(data[0][:answered])
-    expect(contacts[0].call_ended).to eq(data[0][:call_ended])
-    expect(contacts[0].handling_ended).to eq(data[0][:after_call_ended])
-    expect(contacts[0].direction).to eq(data[0][:direction])
-
-    expect(contacts[1].agent_id).to eq(2)
-    expect(contacts[1].service_id).to eq(2)
-    expect(contacts[1].contact_type).not_to be(nil)
-    expect(contacts[1].ticket_id).not_to be(nil)
-    expect(contacts[1].forwarded_to_agent).not_to be(nil)
-    expect(contacts[1].answered).not_to be(nil)
-    expect(contacts[1].call_ended).not_to be(nil)
-    expect(contacts[1].handling_ended).not_to be(nil)
-    expect(contacts[1].direction).not_to be(nil)
-
-    expect(contacts[1].contact_type).to eq(data[1][:contact_type])
-    expect(contacts[1].ticket_id).to eq(data[1][:ticket_id])
-    expect(contacts[1].forwarded_to_agent).to eq(data[1][:forwarded_to_agent])
-    expect(contacts[1].answered).to eq(data[1][:answered])
-    expect(contacts[1].call_ended).to eq(data[1][:call_ended])
-    expect(contacts[1].handling_ended).to eq(data[1][:after_call_ended])
-    expect(contacts[1].direction).to eq(data[1][:direction])
+    jobs = Delayed::Job.all
+    expect(jobs.size).to eq(2)
+    expect(jobs.first.handler).to include("GetServiceContactsJob")
+    expect(jobs.first.handler).to include("service_id: 1")
+    expect(jobs.second.handler).to include("GetServiceContactsJob")
+    expect(jobs.second.handler).to include("service_id: 2")
   end
-
-  it "Ignores results from Agents who are not registered in the system" do 
-    Team.create(id: 1, name: "Helpdesk")
-    Agent.create(id: 1, first_name: "Matti", last_name: "Neuvolainen", team_id: 1)
-    Service.create(id: 2, name: "Neuvonta Eng", team_id: 1)
-    data = FactoryGirl.build(:get_team_contacts_1)
-    allow_any_instance_of(BackendService).to receive(:get_team_contacts).and_return(data)
-    GetTeamContactsJob.new('Helpdesk', '2016-06-01', '2016-06-10').perform
-
-    expect(Contact.all.size).to eq(1)
-  end
-
 end

--- a/spec/services/backend_service_spec.rb
+++ b/spec/services/backend_service_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe BackendService, type: :service do
 
     message = { serviceGroupID: 4, serviceID: 137, teamID: "Helpdesk",
     agentID: 2000049, startDate: "2016-06-14", endDate: "2016-06-15",
-    contactTypes: 'PBX', useServiceTime: true }
+    contactTypes: 'PBX', useServiceTime: false }
 
     expected = [
       {:ticket_id=>"20160614091049336435", 
@@ -122,12 +122,12 @@ RSpec.describe BackendService, type: :service do
     expect(response).to eq(expected)
   end
 
-  it "Should return empty array if there is only non-contact weird numbers" do
+  it "Should return empty array if there is only header data" do
     fixture = File.read("spec/fixtures/backend_service/get_agent_contacts_2.xml")
 
     message = { serviceGroupID: 4, serviceID: 137, teamID: "Helpdesk",
     agentID: 2000049, startDate: "2016-06-14", endDate: "2016-06-15",
-    contactTypes: 'PBX', useServiceTime: true }
+    contactTypes: 'PBX', useServiceTime: false }
 
     expected = []
 
@@ -153,7 +153,7 @@ it "Should return empty array if there is empty response" do
 
     message = { serviceGroupID: 4, serviceID: 137, teamID: "Helpdesk",
     agentID: 2000049, startDate: "2016-06-14", endDate: "2016-06-15",
-    contactTypes: 'PBX', useServiceTime: true }
+    contactTypes: 'PBX', useServiceTime: false }
 
     expected = []
 


### PR DESCRIPTION
GetTeamContactsJob changed to create a separate GetServiceContactsJob for each service associated with the team.
This is necessary to find missed contacts, as they do not have an associated team, but do have an associated service.
GetServiceContacts will fetch all contacts associated with the service for the specified timeframe.

Also slightly refactored TrackAgentStatusesJob to remove unnecessary variable assignments