### PR TITLE
Realtime queue data should now be reliable

### DIFF
--- a/app/jobs/track_queue_items_job.rb
+++ b/app/jobs/track_queue_items_job.rb
@@ -9,7 +9,8 @@ class TrackQueueItemsJob
                     time_in_queue: data[:time_in_queue])
     end
     last_success = Rails.cache.read('track_queue_items_job_last_success')
-    Rails.cache.write('track_queue_items_job_last_success', now) if QueueUpdater.new(now, last_success).update_queue(current)
+    QueueUpdater.new(now, last_success).update_queue(current)
+    Rails.cache.write('track_queue_items_job_last_success', now)
   end
 
   def self.queue_priority

--- a/app/services/queue_updater.rb
+++ b/app/services/queue_updater.rb
@@ -64,8 +64,8 @@ class QueueUpdater
   end
 
   def same_item(item, match)
-    match.created_at <= item.created_at + 1.second &&
-      match.created_at >= item.created_at - 1.second &&
+    match.created_at <= item.created_at + 2.seconds &&
+      match.created_at >= item.created_at - 2.seconds &&
       match.service_id == item.service_id
   end
 end

--- a/app/services/queue_updater.rb
+++ b/app/services/queue_updater.rb
@@ -5,7 +5,7 @@
 # Queue objects do not by default have any unique identifying information, so they are identified by what information they do contain,
 # as well as the time they enter the queue (current time - time_in_queue). This is not guaranteed to be 100% reliable in borderline
 # cases such as when two similar contacts enter the queue (almost) simultaneously or if the time_in_status returned by OC SOAP service
-# is not reliable (for example due to lag). 
+# is not reliable (for example due to lag).
 class QueueUpdater
   include Now
   # Current_time parameter should ALWAYS be current time (Time.zone.now), except for tests
@@ -51,7 +51,7 @@ class QueueUpdater
   end
 
   # Will check for any new items that it can't match to existing old ones. NOTE: It is possible for
-  # the same_item check to fail due to lag in SOAP reply, even if the items are actually the same. 
+  # the same_item check to fail due to lag in SOAP reply, even if the items are actually the same.
   # This means that the same item may be duplicated (the old one will be closed and a new one opened).
   # This is considered acceptable because accurate Queue stats can be calculated from Contact data.
   def check_for_new_items

--- a/spec/services/queue_updater_spec.rb
+++ b/spec/services/queue_updater_spec.rb
@@ -112,20 +112,6 @@ RSpec.describe QueueUpdater, type: :service do
     end
   end
 
-  context 'When it appears that the queue result is not reliable due to lag from SOAP service' do
-    before (:example) do
-      data = [build(:item_2, time_in_queue: "25")]
-      updater(time, time - 1.hour).update_queue(data)
-      updater(time + 10.seconds, time).update_queue(data)
-    end
-
-    it "doesn't make any changes and awaits the next reliable result" do
-      expect(QueueItem.first.open).to be(true)
-      expect(QueueItem.all.length).to eq(1)
-    end
-  end
-
-
   context 'When three very similar items appear in the queue and one of them disappears' do
     before (:example) do
       data1 = [build(:item_1, time_in_queue: "3"), build(:item_1, time_in_queue: "2"), build(:item_1, time_in_queue: "3")]


### PR DESCRIPTION
QueueUpdater will no longer attempt to determine whether the data it receives is reliable or not.
This was producing unwanted behaviour (ie. realtime queue data was not accurate).